### PR TITLE
MSP

### DIFF
--- a/lake/definitions/aha_config.json
+++ b/lake/definitions/aha_config.json
@@ -61,6 +61,8 @@
     }
   },
   "stm": {
+    "msp_type": "pm",
+
     "ps": {
         "inhibition_decay": 0.95,
         "knockout_rate": 0.25,

--- a/lake/definitions/aha_config_msp.json
+++ b/lake/definitions/aha_config_msp.json
@@ -1,0 +1,135 @@
+{
+  "seed": 42,
+
+  "image_shape": [1, 1, 52, 52],
+  "image_resize_factor": 0.5,
+
+  "pretrain_epochs": 10,
+  "pretrain_batch_size": 128,
+  "pretrained_model_path": "./pretrained_model_15.pt",
+
+  "study_steps": 60,
+  "study_batch_size": 20,
+
+  "dataset":  "Omniglot",
+
+  "ltm_type": "vc",
+  "stm_type": "aha",
+
+  "metrics": {
+    "prefixes": ["pc", "pr_rf_", "ec_out_", "ec_out_rf_"],
+    "primary_feature_names": ["study.stm_pc","recall.stm_pr", "study.stm_recon_ec", "recall.stm_recon_ec"],
+    "primary_label_names": ["study.labels", "recall.labels","study.labels", "recall.labels"],
+    "secondary_feature_names": ["recall.stm_pc","study.stm_pr", "recall.stm_recon_ec", "study.stm_recon_ec"],
+    "secondary_label_names": ["recall.labels", "study.labels", "recall.labels", "study.labels"],
+    "comparison_types": ["match_mse", "match_mse", "match_mse", "match_mse"]
+  },
+
+  "ltm": {
+    "learning_rate": 0.001,
+
+    "filters": 121,
+    "kernel_size": 10,
+
+    "stride": 5,
+    "eval_stride": 1,
+    "encoder_padding": "same",
+    "decoder_padding": "same",
+
+    "encoder_nonlinearity": "none",
+    "decoder_nonlinearity": "none",
+
+    "use_bias": true,
+    "use_tied_weights": true,
+    "use_lifetime_sparsity": true,
+
+    "sparsity": 4,
+    "sparsity_output_factor": 1.0,
+
+    "output_pool_size": 4,
+    "output_pool_stride": 4,
+    "output_norm_per_sample": true,
+
+    "classifier": {
+      "learning_rate": 0.001,
+      "weight_decay": 0.000025,
+
+      "input_dropout": 0.0,
+      "hidden_dropout": [],
+
+      "hidden_units": [],
+      "output_units": 20
+    }
+  },
+  "stm": {
+    "build_pm": true,
+    "build_msp": true,
+
+    "ps": {
+        "inhibition_decay": 0.95,
+        "knockout_rate": 0.25,
+        "init_scale": 10.0,
+        "num_units": 225,
+        "sparsity": 10,
+        "use_stub": false
+    },
+    "pc": {
+        "shift_range": false
+    },
+    "pr": {
+        "learning_rate": 0.01,
+        "weight_decay": 0.000025,
+
+        "num_units": 800,
+        "input_dropout": 0.25,
+        "hidden_dropout": 0.0,
+
+        "encoder_nonlinearity": "leaky_relu",
+        "decoder_nonlinearity": "none",
+        "use_bias": true,
+        "norm_inputs": false,
+
+        "noise_type": "s",
+        "noise_mode": "add",
+        "train_with_noise": 0.05,
+        "train_with_noise_pp": 0.005,
+        "test_with_noise": 0.0,
+        "test_with_noise_pp": 0.0,
+
+        "sparsity": 10,
+        "sparsity_boost": 1.0,
+        "sparsen": false,
+        "softmax": false,
+        "shift_bits": false,
+        "shift_range": false,
+        "sum_norm": 10.0,
+        "gain": 1.0
+    },
+    "pm_ec": {
+        "learning_rate": 0.01,
+        "weight_decay": 0.00004,
+
+        "num_units": 100,
+        "input_dropout": 0.0,
+        "hidden_dropout": 0.0,
+
+        "encoder_nonlinearity": "leaky_relu",
+        "decoder_nonlinearity": "leaky_relu",
+        "use_bias": true,
+        "norm_inputs": true
+    },
+    "pm": {
+        "learning_rate": 0.01,
+        "weight_decay": 0.00004,
+
+        "num_units": 100,
+        "input_dropout": 0.0,
+        "hidden_dropout": 0.0,
+
+        "encoder_nonlinearity": "leaky_relu",
+        "decoder_nonlinearity": "leaky_relu",
+        "use_bias": true,
+        "norm_inputs": true
+    }
+  }
+}

--- a/lake/definitions/aha_config_msp.json
+++ b/lake/definitions/aha_config_msp.json
@@ -6,7 +6,6 @@
 
   "pretrain_epochs": 10,
   "pretrain_batch_size": 128,
-  "pretrained_model_path": "./pretrained_model_15.pt",
 
   "study_steps": 60,
   "study_batch_size": 20,
@@ -48,22 +47,11 @@
 
     "output_pool_size": 4,
     "output_pool_stride": 4,
-    "output_norm_per_sample": true,
-
-    "classifier": {
-      "learning_rate": 0.001,
-      "weight_decay": 0.000025,
-
-      "input_dropout": 0.0,
-      "hidden_dropout": [],
-
-      "hidden_units": [],
-      "output_units": 20
-    }
+    "output_pool_padding": 0,
+    "output_norm_per_sample": true
   },
   "stm": {
-    "build_pm": true,
-    "build_msp": true,
+    "msp_type": "ca1",
 
     "ps": {
         "inhibition_decay": 0.95,
@@ -105,7 +93,7 @@
         "sum_norm": 10.0,
         "gain": 1.0
     },
-    "pm_ec": {
+    "ca3_ca1": {
         "learning_rate": 0.01,
         "weight_decay": 0.00004,
 
@@ -118,18 +106,20 @@
         "use_bias": true,
         "norm_inputs": true
     },
-    "pm": {
-        "learning_rate": 0.01,
-        "weight_decay": 0.00004,
+    "ca1": {
+        "learning_rate": 0.001,
+        "weight_decay": 0.000025,
 
-        "num_units": 100,
+        "num_units": 800,
         "input_dropout": 0.0,
         "hidden_dropout": 0.0,
 
         "encoder_nonlinearity": "leaky_relu",
         "decoder_nonlinearity": "leaky_relu",
         "use_bias": true,
-        "norm_inputs": true
+        "norm_inputs": false,
+
+        "ca3_recall": true
     }
   }
 }


### PR DESCRIPTION
- Added flag to build PM or CA1/CA3_CA1 pathway
- Introduced two new networks:
    - CA1 (auto-encoder on ECin) - continuously trains without resetting, bigger, slower lr
    - CA3_CA1 (reproducing CA1 hidden, from CA3 pattern) - resets alongside PR, fast lr
- During recall, the CA1 reconstruction of EC will be driven by CA3 (configurable by param, on by default)
- Added decoding through layers to reconstruct the CA1 <=> ECout back into pixels (through EC => LTM)
- Introduced unpooling in the VC to facilitate decoding backwards through layers

See also diary for more notes on issues/debugging.

https://docs.google.com/document/u/1/d/1oI_VNPB-ldBKQZ4dT5dWJF5ifjh9NrCmKqVv0lggIMA/edit?usp=drive_web&ouid=101721042953729020097

